### PR TITLE
Fix #2: Add bits parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Output:
     genesis hash found!
     nonce: 2083236893
     genesis hash: 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+Create the regtest genesis hash found in Bitcoin
+
+    python genesis.py -z "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks" -n 2 -t 1296688602 -b 0x207fffff
+
 Create the original genesis hash found in Litecoin
 
     python genesis.py -a scrypt -z "NY Times 05/Oct/2011 Steve Jobs, Apple’s Visionary, Dies at 56" -p "040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9" -t 1317972665 -n 2084524493

--- a/genesis.py
+++ b/genesis.py
@@ -129,12 +129,10 @@ def generate_hash(data_block, algorithm, start_nonce, target):
   print 'Searching for genesis hash..'
   nonce           = start_nonce
   last_updated    = time.time()
-  difficulty      = float(0xFFFF) * 2**208 / target
-  update_interval = int(1000000 * difficulty)
 
   while True:
     sha256_hash, header_hash = generate_hashes_from_block(data_block, algorithm)
-    last_updated             = calculate_hashrate(nonce, update_interval, difficulty, last_updated)
+    last_updated             = calculate_hashrate(nonce, last_updated)
     if is_genesis_hash(header_hash, target):
       if algorithm == "X11" or algorithm == "X13" or algorithm == "X15":
         return (header_hash, nonce)
@@ -176,11 +174,11 @@ def is_genesis_hash(header_hash, target):
   return int(header_hash.encode('hex_codec'), 16) < target
 
 
-def calculate_hashrate(nonce, update_interval, difficulty, last_updated):
-  if nonce % update_interval == update_interval - 1:
+def calculate_hashrate(nonce, last_updated):
+  if nonce % 1000000 == 999999:
     now             = time.time()
-    hashrate        = round(update_interval/(now - last_updated))
-    generation_time = round(difficulty * pow(2, 32) / hashrate / 3600, 1)
+    hashrate        = round(1000000/(now - last_updated))
+    generation_time = round(pow(2, 32) / hashrate / 3600, 1)
     sys.stdout.write("\r%s hash/s, estimate: %s h"%(str(hashrate), str(generation_time)))
     sys.stdout.flush()
     return now


### PR DESCRIPTION
Note: In the genesis block, difficulty == 1 (that's the 1st commit).
That's because a difficulty of 1 is based off the highest possible target, aka nBits.
This works with all the examples provided in README.md, and also the regtest on Bitcoin, that I added in README.
This is the example with regtest:
```
python genesis.py -z "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks" -n 2 -t 1296688602 -b 0x207fffff
```
And the output expected:
```
algorithm: SHA256
merkle hash: 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
pszTimestamp: The Times 03/Jan/2009 Chancellor on brink of second bailout for banks
pubkey: 04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f
time: 1296688602
bits: 0x207fffff
Searching for genesis hash..
genesis hash found!
nonce: 2
genesis hash: 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
```